### PR TITLE
docs: expand README with architecture, run/deploy instructions and add diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,265 @@
-# working-title
+# Working Title
 
-NEED HUMAN LOL
+![Working Title Architecture](https://raw.githubusercontent.com/Chibuzor-Egbo/working-title/main/docs/architecture-diagram.svg)
 
-## 1
+**Download diagram (public URL):** [architecture-diagram.svg](https://raw.githubusercontent.com/Chibuzor-Egbo/working-title/main/docs/architecture-diagram.svg)
 
-the repo has to be created manually
+## Project overview
 
-`aws ecr create-repository --repository-name wt --region us-east-1`
+Working Title is a full-stack DevOps demo project that deploys a Flask todo application on AWS with an automated CI/CD workflow and built-in monitoring.
 
-enable terraform still manage the repo even after manual creation
+The repository includes:
 
-`terraform import module.compute.aws_ecr_repository.this wt`
+- **Application code** (Flask + SQLAlchemy + frontend assets).
+- **Containerization** for local and remote runtime (Docker).
+- **Infrastructure as Code** for AWS provisioning (Terraform).
+- **Configuration management** for host and service setup (Ansible).
+- **Observability stack** (Prometheus, Grafana, Alertmanager + Slack alerts).
 
-## 2
+### What is provisioned in AWS
 
-the github actions role has to be created manually
+- **VPC** with public subnets (for EC2) and private subnets (for RDS).
+- **App EC2 instance** (pulls and runs the app image from ECR).
+- **Monitoring EC2 instance** (runs Prometheus/Grafana/Alertmanager via Docker Compose).
+- **RDS PostgreSQL** instance in private subnets.
+- **ECR repository** (`wt`) for image storage.
+- **Terraform remote state backend** using S3 + DynamoDB lock table.
 
-```setting up OIDC provider
-aws iam create-open-id-connect-provider \
- --url https://token.actions.githubusercontent.com \
- --client-id-list sts.amazonaws.com \
- --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+### App endpoints
+
+- `/` – UI
+- `/todos` – GET, POST
+- `/todos/<id>` – PUT, DELETE
+- `/health` – healthcheck
+- `/metrics` – Prometheus metrics endpoint
+
+---
+
+## tech stack
+
+### App/runtime
+
+- Python (3.11 image runtime, 3.12 used in CI)
+- Flask
+- Flask-SQLAlchemy
+- PostgreSQL
+- pytest
+
+### DevOps / infra / automation
+
+- Docker + Docker Compose
+- Terraform (AWS modules for networking, compute, database, monitoring)
+- Ansible (roles: `common`, `app`, `monitoring`)
+- GitHub Actions (CI + CD)
+
+### Observability
+
+- Prometheus
+- Grafana (provisioned datasource + dashboard)
+- Alertmanager (Slack notifications)
+
+---
+
+## how to run locally (docker compose)
+
+Local compose file: `app/compose.yaml`
+
+It starts:
+
+- `db` (PostgreSQL 15)
+- `web` (Flask app)
+- `prometheus`
+- `grafana`
+
+### 1) prerequisites
+
+- Docker
+- Docker Compose plugin
+
+### 2) create local env file
+
+Create `app/.env`:
+
+```env
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=working_title
+DATABASE_URL=postgresql://postgres:postgres@db:5432/working_title
+SECRET_KEY=dev-secret
 ```
 
-#### incase u dont have the policy
+### 3) start the stack
 
-cat > trust-policy.json <<EOF
-{
-"Version": "2012-10-17",
-"Statement": [
-{
-"Effect": "Allow",
-"Principal": {
-"Federated": "arn:aws:iam::162322546212:oidc-provider/token.actions.githubusercontent.com"
-},
-"Action": "sts:AssumeRoleWithWebIdentity",
-"Condition": {
-"StringEquals": {
-"token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-},
-"StringLike": {
-"token.actions.githubusercontent.com:sub": "repo:Chibuzor-Egbo/working-title:*"
-}
-}
-}
-]
-}
-EOF
-
-```role creation
-aws iam create-role \
- --role-name github-actions-role \
- --assume-role-policy-document file://trust-policy.json
+```bash
+cd app
+docker compose up --build -d
 ```
 
-```attach permissions to role
-aws iam attach-role-policy \
- --role-name github-actions-role \
- --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
+### 4) verify
+
+- App: http://localhost:5001
+- Prometheus: http://localhost:9090
+- Grafana: http://localhost:3001
+
+Quick checks:
+
+```bash
+curl http://localhost:5001/health
+curl http://localhost:5001/metrics
 ```
 
-## 3
+### 5) stop
 
-always update your public IP in secrets
+```bash
+cd app
+docker compose down
+```
 
-## GRAFANA SETUP
+---
 
-login
-add prom as a data source "http://prometheus:9090"
+## how to deploy (step-by-step with the pipeline)
+
+Pipelines:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/cd.yml`
+
+### 0) one-time bootstrap
+
+1. **Provision Terraform backend resources** from `terraform/bootstrap` (S3 bucket + DynamoDB table).
+2. **Create ECR repo** (if not already created by Terraform in your flow):
+   ```bash
+   aws ecr create-repository --repository-name wt --region us-east-1
+   ```
+3. If repo was created manually, import it so Terraform manages it:
+   ```bash
+   terraform import module.compute.aws_ecr_repository.this wt
+   ```
+4. **Create GitHub OIDC provider + IAM role** trusted by `token.actions.githubusercontent.com`.
+5. Set repo **variables** and **secrets** used by workflows.
+
+Required variables (from `cd.yml`):
+
+- `BUCKET_NAME`, `DYNAMODBTABLE_NAME`
+- `VPC_CIDR`, `PUB1_CIDR`, `PUB2_CIDR`, `PRIV1_CIDR`, `PRIV2_CIDR`
+- `AZ1`, `AZ2`
+- `MY_IP`
+- `INSTANCE_TYPE`
+- `DB_USER`
+
+Required secrets (from `ci.yml`/`cd.yml`):
+
+- `AWS_ROLE_ARN`
+- `DB_PASSWORD`
+- `WT_KEY`, `MON_KEY`
+- `ANSIBLE_VAULT_PASS`
+- `SLACK_WEBHOOK_URL`
+
+> `MY_IP` is CIDR-restricted ingress for monitoring ports. Update it when your public IP changes.
+
+### 1) CI flow (`ci.yml`)
+
+Triggered on PRs and pushes to `main`:
+
+1. Checkout code
+2. Setup Python 3.12
+3. Install dependencies
+4. Run tests (`pytest app/`)
+5. On push to `main` only:
+   - Build Docker image from `app/`
+   - Configure AWS credentials via OIDC (`AWS_ROLE_ARN`)
+   - Login to ECR
+   - Push image tagged with commit SHA
+
+### 2) CD flow (`cd.yml`)
+
+Triggered on push to `main`:
+
+1. Checkout code
+2. Setup Terraform
+3. Configure AWS credentials via OIDC
+4. Generate `terraform/terraform.tfvars` from repo vars/secrets
+5. `terraform init`
+6. `terraform plan -out=tfplan`
+7. Upload plan artifact
+8. Wait for manual approval
+9. `terraform apply -auto-approve tfplan`
+10. Export Terraform outputs to workflow env:
+    - app public IP
+    - monitoring public IP
+    - DB endpoint
+    - app private IP
+11. Generate dynamic Ansible inventory
+12. Add hosts to SSH `known_hosts`
+13. Run `ansible-playbook ansible/site.yml` with runtime extra vars:
+    - `ecr_repo`
+    - `image_tag`
+    - `db_host`
+    - `app_private_ip`
+    - `slack_webhook_url`
+
+### 3) post-terraform Ansible behavior
+
+- **common role** (all hosts)
+  - Installs Docker, docker-compose, python3-pip, unzip, awscli
+  - Ensures Docker is enabled/running
+- **app role** (app host)
+  - Authenticates to ECR
+  - Pulls image tag from CI
+  - Runs app container with DB env vars
+- **monitoring role** (monitoring host)
+  - Writes Prometheus scrape config (targeting app private IP)
+  - Writes alert rules + Alertmanager config
+  - Provisions Grafana datasource/dashboard files
+  - Starts monitoring stack via docker-compose
+
+---
+
+## how the monitoring works
+
+### 1) app instrumentation
+
+`app/app.py` exposes and updates these metrics:
+
+- `http_requests_total{method,endpoint,http_status}` (Counter)
+- `http_request_duration_seconds{method,endpoint}` (Histogram)
+- `db_active_connections` (Gauge)
+
+Metrics are exposed on `/metrics`.
+
+### 2) scraping
+
+Prometheus on the monitoring server scrapes:
+
+- `job_name: flask-app`
+- target: `<app_private_ip>:5000`
+
+### 3) alert rules
+
+Defined in `ansible/roles/monitoring/files/alerts.yml`:
+
+- **AppDown**: app scrape target down for >1 minute
+- **HighErrorRate**: 5xx error rate >5% over 2 minutes
+
+### 4) alert routing
+
+Alertmanager sends alerts to Slack webhook (`SLACK_WEBHOOK_URL`) and routes to `#prometheus-alerts`.
+
+### 5) dashboards
+
+Grafana is provisioned automatically with:
+
+- Prometheus datasource (`http://prometheus:9090`)
+- Preloaded dashboard JSON from role files
+
+---
+
+## repo structure
+
+```text
+.
+├── app/                 # Flask app, Dockerfile, compose, tests, local Prometheus config
+├── terraform/           # Root Terraform + modules + bootstrap backend
+├── ansible/             # site.yml, inventory, app/common/monitoring roles
+└── .github/workflows/   # CI and CD pipelines
+```

--- a/docs/architecture-diagram.svg
+++ b/docs/architecture-diagram.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" viewBox="0 0 1400 900">
+  <defs>
+    <style>
+      .title{font:700 28px Arial, sans-serif; fill:#0f172a}
+      .label{font:600 16px Arial, sans-serif; fill:#0f172a}
+      .small{font:500 13px Arial, sans-serif; fill:#334155}
+      .box{fill:#ffffff;stroke:#1e293b;stroke-width:2}
+      .cloud{fill:#f0f9ff;stroke:#94a3b8;stroke-width:2}
+      .vpc{fill:#ecfdf5;stroke:#22c55e;stroke-width:2}
+      .pub{fill:#ffffff;stroke:#10b981;stroke-width:2}
+      .priv{fill:#ffffff;stroke:#8b5cf6;stroke-width:2}
+      .mon{fill:#ffffff;stroke:#f59e0b;stroke-width:2}
+      .arrow{stroke:#0f172a;stroke-width:2;fill:none;marker-end:url(#a)}
+    </style>
+    <marker id="a" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#0f172a" />
+    </marker>
+  </defs>
+
+  <text x="420" y="50" class="title">Working Title - AWS Architecture</text>
+
+  <!-- CI/CD control plane -->
+  <rect x="40" y="120" width="260" height="90" class="box"/>
+  <text x="70" y="155" class="label">GitHub Actions</text>
+  <text x="70" y="180" class="small">CI + CD pipeline</text>
+
+  <rect x="40" y="240" width="260" height="70" class="box"/>
+  <text x="70" y="282" class="label">Terraform</text>
+
+  <rect x="40" y="340" width="260" height="70" class="box"/>
+  <text x="70" y="382" class="label">Ansible</text>
+
+  <rect x="40" y="440" width="260" height="70" class="box"/>
+  <text x="70" y="482" class="label">Amazon ECR (wt)</text>
+
+  <!-- AWS cloud -->
+  <rect x="350" y="90" width="1000" height="760" rx="10" class="cloud"/>
+  <text x="380" y="125" class="label">AWS Cloud (us-east-1)</text>
+
+  <!-- VPC -->
+  <rect x="390" y="140" width="920" height="670" rx="10" class="vpc"/>
+  <text x="420" y="175" class="label">VPC</text>
+
+  <!-- Public subnet 1 -->
+  <rect x="430" y="210" width="380" height="280" class="pub"/>
+  <text x="450" y="240" class="label">Public Subnet 1 (App)</text>
+
+  <rect x="470" y="280" width="300" height="150" class="box"/>
+  <text x="495" y="320" class="label">App EC2</text>
+  <text x="495" y="345" class="small">Flask container</text>
+  <text x="495" y="368" class="small">Port 5000</text>
+
+  <!-- Public subnet 2 -->
+  <rect x="860" y="210" width="410" height="360" class="mon"/>
+  <text x="880" y="240" class="label">Public Subnet 2 (Monitoring)</text>
+
+  <rect x="900" y="280" width="330" height="240" class="box"/>
+  <text x="925" y="315" class="label">Monitoring EC2</text>
+  <text x="925" y="345" class="small">Prometheus :9090</text>
+  <text x="925" y="370" class="small">Grafana :3000</text>
+  <text x="925" y="395" class="small">Alertmanager :9093</text>
+
+  <!-- Private subnets / RDS -->
+  <rect x="430" y="530" width="380" height="230" class="priv"/>
+  <text x="450" y="560" class="label">Private Subnets (DB)</text>
+
+  <rect x="500" y="600" width="240" height="110" class="box"/>
+  <text x="525" y="645" class="label">RDS PostgreSQL</text>
+
+  <!-- Slack external -->
+  <rect x="1120" y="640" width="190" height="90" class="box"/>
+  <text x="1175" y="692" class="label">Slack</text>
+
+  <!-- Flows -->
+  <path d="M300 165 L470 320" class="arrow"/>
+  <text x="315" y="150" class="small">deploy</text>
+
+  <path d="M300 275 L470 280" class="arrow"/>
+  <text x="320" y="265" class="small">provision infra</text>
+
+  <path d="M300 375 L470 360" class="arrow"/>
+  <text x="325" y="365" class="small">configure hosts</text>
+
+  <path d="M300 475 L470 395" class="arrow"/>
+  <text x="330" y="455" class="small">push/pull image</text>
+
+  <path d="M770 350 L900 350" class="arrow"/>
+  <text x="790" y="335" class="small">metrics scrape</text>
+
+  <path d="M620 430 L620 600" class="arrow"/>
+  <text x="635" y="515" class="small">SQL 5432</text>
+
+  <path d="M1230 520 L1230 640" class="arrow"/>
+  <text x="1240" y="585" class="small">alerts</text>
+</svg>


### PR DESCRIPTION
### Motivation

- Provide a clear, user-friendly project overview and step-by-step instructions so contributors can bootstrap, run, and operate the demo deployment. 
- Document the CI/CD, infrastructure, and observability design and required variables so infra provisioning and deployments are reproducible. 

### Description

- Rewrote `README.md` to include a full project overview, tech stack, app endpoints, local `docker compose` run steps, CI/CD flow, Terraform/Ansible behavior, observability details, and repository structure. 
- Added `docs/architecture-diagram.svg` showing the AWS architecture (VPC, public/private subnets, App EC2, Monitoring EC2, RDS, ECR and CI/CD control plane). 
- Included explicit bootstrap and deployment commands such as `aws ecr create-repository`, `terraform import`, and the list of required workflow variables and secrets. 

### Testing

- This is a documentation-only change so no tests were modified or executed as part of this PR. 
- The repository CI remains configured to run `pytest app/` on PRs and pushes to `main` and will continue to run unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea1412110832dbc456148be2e33aa)